### PR TITLE
Added option to skip apache changes and others small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@ If you support multiple products/projects that are built using either brand new 
 Caveats
 -------
 
-For users of OSX only who have installed PHP via [Homebrew] and for PHP version 5.3, 5.4 and 5.5 only.
+For users of OSX only who have installed PHP via [Homebrew] and for PHP version 5.3, 5.4, 5.5 and 5.6 only.
 
 Your Apache config must be setup using the same paths as below. Replace homebrew's default /usr/local with the output from your `brew --prefix` if needed.
 ```sh
 #LoadModule php5_module /usr/local/opt/php53/libexec/apache2/libphp5.so
 #LoadModule php5_module /usr/local/opt/php54/libexec/apache2/libphp5.so
 #LoadModule php5_module /usr/local/opt/php55/libexec/apache2/libphp5.so
+#LoadModule php5_module /usr/local/opt/php56/libexec/apache2/libphp5.so
 ```
 
 Version
 ----
 
-1.3
+1.4
 
 Installation
 --------------
@@ -28,9 +29,9 @@ Installation
 brew install brew-php-switcher
 ```
 
-Where **55** exists, please replace with syntax of **53**,**54** or **55** depending on which version is required.
+Where **56** exists, please replace with syntax of **53**, **54**, **55** or **56** depending on which version is required.
 ```sh
-brew-php-switcher 55
+brew-php-switcher 56
 ```
 
 

--- a/phpswitch.sh
+++ b/phpswitch.sh
@@ -19,7 +19,7 @@ if [[ -z "$1" ]]
 then
 	echo "usage: brew-php-switcher version [-s]"; echo;
 	echo "    version    one of:" ${php_array[@]};
-	echo "    -a         skip change of mod_php on apache"; echo;
+	echo "    -s         skip change of mod_php on apache"; echo;
 	exit
 fi
 

--- a/phpswitch.sh
+++ b/phpswitch.sh
@@ -2,21 +2,40 @@
 # Creator: Phil Cook
 # Email: phil@phil-cook.com
 # Twitter: @p_cook
+brew_prefix=$(brew --prefix | sed 's#/#\\\/#g')
+
 php_array=("php53" "php54" "php55" "php56")
 php_installed_array=()
 php_version="php$1"
-apache_conf_path="/etc/apache2/httpd.conf"
-brew_prefix=$(brew --prefix | sed 's#/#\\\/#g')
 php_opt_path="$brew_prefix\/opt\/"
-php_lib_path="\/libexec\/apache2\/libphp5.so"
-php_mod_path="$php_opt_path$php_version$php_lib_path"
+
+apache_change=1
+apache_conf_path="/etc/apache2/httpd.conf"
+apache_php_lib_path="\/libexec\/apache2\/libphp5.so"
+apache_php_mod_path="$php_opt_path$php_version$apache_php_lib_path"
 
 # Has the user submitted a version required
 if [[ -z "$1" ]]
 then
-	echo "Please set which version you want to switch to. E.g. brew-php-switcher 53"
+	echo "usage: brew-php-switcher version [-s]"; echo;
+	echo "    version    one of:" ${php_array[@]};
+	echo "    -a         skip change of mod_php on apache"; echo;
 	exit
 fi
+
+while [[ ${2:0:1} = '-' ]] ; do
+	N=1
+	L=${#1}
+	while [[ $N -lt $L ]] ; do
+		case ${2:$N:1} in
+			's') apache_change=0 ;;
+			*) echo $USAGE
+			exit 1 ;;
+		esac
+		N=$(($N+1))
+	done
+	shift
+done
 
 # What versions of php are installed via brew
 for i in ${php_array[@]}
@@ -43,19 +62,21 @@ then
 			fi
 		done
 		brew link "$php_version"
-		echo "You will need sudo power from now on"
-		echo "Switching your apache conf"
-		for j in ${php_installed_array[@]}
-		do
-			sudo sed -i.bak "s/^LoadModule[ \t]php5_module[ \t]$php_opt_path$j$php_lib_path/\#LoadModule php5_module $php_opt_path$j$php_lib_path/g" $apache_conf_path
-		done
-		sudo sed -i.bak "s/^\#LoadModule[ \t]php5_module[ \t]$php_mod_path/LoadModule php5_module $php_mod_path/g" $apache_conf_path
-		echo "Restarting apache"
-		sudo apachectl restart
+		if [[ $apache_change -eq 1 ]]; then
+			echo "You will need sudo power from now on"
+			echo "Switching your apache conf"
+			for j in ${php_installed_array[@]}
+			do
+				sudo sed -i.bak "s/^LoadModule[ \t]php5_module[ \t]$php_opt_path$j$apache_php_lib_path/\#LoadModule php5_module $php_opt_path$j$apache_php_lib_path/g" $apache_conf_path
+			done
+			sudo sed -i.bak "s/^\#LoadModule[ \t]php5_module[ \t]$apache_php_mod_path/LoadModule php5_module $apache_php_mod_path/g" $apache_conf_path
+			echo "Restarting apache"
+			sudo apachectl restart
+		fi
 		echo "All done!"
 	else
-		echo "Sorry, but $php_version is not installed via brew. Install by running brew install $php_version"
+		echo "Sorry, but $php_version is not installed via brew. Install by running: brew install $php_version"
 	fi
 else
-	echo "Unknown version of PHP. PHP Switcher can only handle arguements of 53,54,55"
+	echo "Unknown version of PHP. PHP Switcher can only handle arguments of:" ${php_array[@]}
 fi


### PR DESCRIPTION
Hey Phill, here is my contribution:

* Added option to skip apache changes for users that not need it.

The apache change and reload should be optionally skipped for users that does not need it to be changed and [re]started after a php version switch. I added the [-a] optional argument for this case.

* Updated output messages

I changed messages like usage instructions and the warnings when the version is not installed or was not passed on the program.

* Updated README

This change is to advertise the php56 compatibility and also updated the version to 1.4 to allow releasing