### PR TITLE
Add initial support for php70 #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you support multiple products/projects that are built using either brand new 
 Caveats
 -------
 
-For users of OSX only who have installed PHP via [Homebrew] and for PHP version 5.3, 5.4, 5.5 and 5.6 only.
+For users of OSX only who have installed PHP via [Homebrew] and for PHP version 5.3, 5.4, 5.5, 5.6 and 7.0 only.
 
 Your Apache config must be setup using the same paths as below. Replace homebrew's default /usr/local with the output from your `brew --prefix` if needed.
 ```sh
@@ -21,7 +21,7 @@ Your Apache config must be setup using the same paths as below. Replace homebrew
 Version
 ----
 
-1.4
+1.5
 
 Installation
 --------------
@@ -29,7 +29,7 @@ Installation
 brew install brew-php-switcher
 ```
 
-Where **56** exists, please replace with syntax of **53**, **54**, **55** or **56** depending on which version is required.
+Where **56** exists, please replace with syntax of **53**, **54**, **55**, **56** or **70** depending on which version is required.
 ```sh
 brew-php-switcher 56
 ```
@@ -44,5 +44,5 @@ License
 
 MIT
 
-[Homebrew]:http://http://brew.sh/
-[@p_cook]:http://twitter.com/p_cook
+[Homebrew]: http://brew.sh/
+[@p_cook]: http://twitter.com/p_cook


### PR DESCRIPTION
Hi,
just a quick take on mentioned task. Please review it, it has been ages since I have done any scripting in bash.

Two things to mention:
+ I thought about naming convention for `php7x`. Even though it's still beta, I went on with current conversion and didn't do anything like `70b` or similar.
+ As for php7x apache module name and key for `httpd.conf` got changed, I needed some conditional logic.

Also, I noticed there is something broken with substitution of `LoadModule php5_module ...` in `httpd.conf` in HEAD. It's not related to my changes. I didn't change any logic except naming, but I will revisit the matter later. 