### PR TITLE
Remove duplicate "brew ls"

### DIFF
--- a/phpswitch.sh
+++ b/phpswitch.sh
@@ -105,10 +105,7 @@ then
 		echo "Switching your shell"
 		for i in ${php_installed_array[@]}
 		do
-			if [[ -n $(brew ls --versions $i) ]]
-			then
-				brew unlink $i
-			fi
+			brew unlink $i
 		done
 		brew link "$php_version"
 


### PR DESCRIPTION
The second "brew ls" in this script is redundant because ``php_installed_array`` gets populated by the result of ``brew ls`` in line 75-81.