### PR TITLE
Update switcher to support PHP 7.3

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -10,8 +10,10 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
     brew install php@7.1
     brew unlink php@7.1
     brew install php@7.2
-    brew link --overwrite php@7.2
     brew unlink php@7.2
+    brew install php@7.3
+    brew link --overwrite php@7.3
+    brew unlink php@7.3
 
     echo 'Installed all PHP versions.'
 fi

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 error=0
-for version in '5.6' '7.0' '7.1' '7.2'; do
+for version in '5.6' '7.0' '7.1' '7.2' '7.3'; do
     . `echo $(dirname $0)"/../phpswitch.sh"` $version -s > /dev/null
     switched=$(php -v | grep -e '^PHP' | cut -d' ' -f2 | cut -d. -f1,2)
     if [ "$version" != "$switched" ]; then

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you support multiple products/projects that are built using either brand new 
 Caveats
 -------
 
-For users of OSX only who have installed PHP via [Homebrew] and for PHP version 5.6, 7.0, 7.1 and 7.2 only.
+For users of OSX only who have installed PHP via [Homebrew] and for PHP version 5.6, 7.0, 7.1, 7.2 and 7.3 only.
 
 Your Apache config must have native osx PHP module commented out.
 ```sh
@@ -21,6 +21,7 @@ Brew PHP Switcher will automatically add the [Homebrew]'s PHP module location in
 #LoadModule php7_module /usr/local/opt/php@7.0/lib/httpd/modules/libphp7.so
 #LoadModule php7_module /usr/local/opt/php@7.1/lib/httpd/modules/libphp7.so
 #LoadModule php7_module /usr/local/opt/php@7.2/lib/httpd/modules/libphp7.so
+#LoadModule php7_module /usr/local/opt/php@7.3/lib/httpd/modules/libphp7.so
 ```
 
 Version
@@ -34,7 +35,7 @@ Installation
 brew install brew-php-switcher
 ```
 
-Where **5.6** exists, please replace with syntax of **5.6**, **7.0**, **7.1**, or **7.2** depending on which version is required.
+Where **5.6** exists, please replace with syntax of **5.6**, **7.0**, **7.1**, **7.2**, or **7.3** depending on which version is required.
 ```sh
 brew-php-switcher 5.6
 ```

--- a/phpswitch.sh
+++ b/phpswitch.sh
@@ -9,9 +9,9 @@ osx_version=$((${osx_major_version} * 10000 + ${osx_minor_version} * 100 + ${osx
 
 brew_prefix=$(brew --prefix | sed 's#/#\\\/#g')
 
-brew_array=("5.6","7.0","7.1","7.2")
-php_array=("php@5.6" "php@7.0" "php@7.1" "php@7.2")
-valet_support_php_version_array=("php@5.6" "php@7.0" "php@7.1" "php@7.2")
+brew_array=("5.6","7.0","7.1","7.2","7.3")
+php_array=("php@5.6" "php@7.0" "php@7.1" "php@7.2" "php@7.3")
+valet_support_php_version_array=("php@5.6" "php@7.0" "php@7.1" "php@7.2" "php@7.3")
 php_installed_array=()
 php_version="php@$1"
 php_opt_path="$brew_prefix\/opt\/"


### PR DESCRIPTION
PHP 7.3 was released yesterday and the relevant brew formulas were made available today so a quick merging of these changes to support php@7.3 would be greatly appreciated @philcook 🙂