### PR TITLE
ci: add tap for deprecated formulae like PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ osx_image: xcode9.4
 
 addons:
   homebrew:
+    taps: exolnet/homebrew-deprecated
     packages:
       - php@5.6
       - php@7.1


### PR DESCRIPTION
This adds PHP 5.6 again.