### PR TITLE
resolve issue #68

### DIFF
--- a/phpswitch.sh
+++ b/phpswitch.sh
@@ -153,7 +153,8 @@ $comment_apache_module_string\\
             done
             sudo sed -i.bak "s/\#LoadModule $php_module $apache_php_mod_path/LoadModule $php_module $apache_php_mod_path/g" $apache_conf_path
             echo "Restarting apache"
-            sudo apachectl restart
+            sudo apachectl stop
+            sudo apachectl start
         fi
 
         # Switch valet


### PR DESCRIPTION
- for some reason `apachectl restart` will stop apache fine but not restart it properly; changing the commands to explicitly `apachectl stop` and `apachectl start` resolves this issue

resolves #68 