### PR TITLE
feat(php-version): adds PHP 8.5 support to phpswitch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Installation
 brew install brew-php-switcher
 ```
 
-Where **5.6** exists, please replace with syntax of **5.6**, **7.0**, **7.1**, **7.2**, **7.3**, **7.4**, **8.0**, **8.1**, **8.2**, **8.3** or **8.4** depending on which version is required.
+Where **5.6** exists, please replace with syntax of **5.6**, **7.0**, **7.1**, **7.2**, **7.3**, **7.4**, **8.0**, **8.1**, **8.2**, **8.3**, **8.4** or **8.5** depending on which version is required.
 ```sh
 brew-php-switcher 5.6
 ```

--- a/phpswitch.sh
+++ b/phpswitch.sh
@@ -9,9 +9,9 @@ osx_version=$((${osx_major_version} * 10000 + ${osx_minor_version} * 100 + ${osx
 
 brew_prefix=$(brew --prefix | sed 's#/#\\\/#g')
 
-brew_array=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1" "8.2", "8.3", "8.4")
-php_array=("php@5.6" "php@7.0" "php@7.1" "php@7.2" "php@7.3" "php@7.4" "php@8.0" "php@8.1" "php@8.2" "php@8.3" "php@8.4")
-valet_support_php_version_array=("php@5.6" "php@7.0" "php@7.1" "php@7.2" "php@7.3" "php@7.4" "php@8.0" "php@8.1" "php@8.2" "php@8.3" "php@8.4")
+brew_array=("5.6" "7.0" "7.1" "7.2" "7.3" "7.4" "8.0" "8.1" "8.2", "8.3", "8.4", "8.5")
+php_array=("php@5.6" "php@7.0" "php@7.1" "php@7.2" "php@7.3" "php@7.4" "php@8.0" "php@8.1" "php@8.2" "php@8.3" "php@8.4", "php@8.5")
+valet_support_php_version_array=("php@5.6" "php@7.0" "php@7.1" "php@7.2" "php@7.3" "php@7.4" "php@8.0" "php@8.1" "php@8.2" "php@8.3" "php@8.4" "php@8.5")
 php_installed_array=()
 php_version="php@$1"
 php_opt_path="$brew_prefix\/opt\/"


### PR DESCRIPTION
Updates the `brew_array`, `php_array`, and `valet_support_php_version_array` to include PHP 8.5, enabling the script to switch to the latest PHP version.